### PR TITLE
Protect from a never ending loop by specifically querying with id as a parameter

### DIFF
--- a/api/src/java/org/sakaiproject/attendance/hbm/AttendanceSite.hbm.xml
+++ b/api/src/java/org/sakaiproject/attendance/hbm/AttendanceSite.hbm.xml
@@ -58,7 +58,10 @@
     </query>
 
     <query name="getAttendanceSiteBatch">
-        <![CDATA[SELECT id FROM AttendanceSite attendanceSite WHERE (attendanceSite.syncTime IS NULL OR attendanceSite.syncTime < :syncTime)]]>
+        <![CDATA[SELECT id FROM AttendanceSite attendanceSite
+            WHERE (attendanceSite.syncTime IS NULL OR attendanceSite.syncTime < :syncTime) AND id > :id
+            ORDER BY id ASC
+        ]]>
     </query>
 
     <query name="getAttendanceSitesInSync">

--- a/impl/src/java/org/sakaiproject/attendance/dao/AttendanceDao.java
+++ b/impl/src/java/org/sakaiproject/attendance/dao/AttendanceDao.java
@@ -245,7 +245,7 @@ public interface AttendanceDao {
 	 * Return a batch of AttendanceSites
 	 * @return a List of AttendanceSite IDs (max 5)
 	 */
-	List<Long> getAttendanceSiteBatch(Date syncTime);
+	List<Long> getAttendanceSiteBatch(Date syncTime, Long lastId);
 
 	/**
 	 * Return a list of all AttendanceSites In Sync

--- a/impl/src/java/org/sakaiproject/attendance/dao/impl/AttendanceDaoImpl.java
+++ b/impl/src/java/org/sakaiproject/attendance/dao/impl/AttendanceDaoImpl.java
@@ -576,12 +576,13 @@ public class AttendanceDaoImpl extends HibernateDaoSupport implements Attendance
 	 * {@inheritDoc}
 	 */
 	@SuppressWarnings("unchecked")
-	public List<Long> getAttendanceSiteBatch(final Date syncTime) {
+	public List<Long> getAttendanceSiteBatch(final Date syncTime, final Long lastId) {
 		final HibernateCallback<List<Long>> hcb = new HibernateCallback<List<Long>>() {
 			@Override
 			public List<Long> doInHibernate(Session session) throws HibernateException, SQLException {
 				Query q = session.getNamedQuery(QUERY_GET_ATTENDANCE_SITE_BATCH);
 				q.setTimestamp(SYNC_TIME, syncTime);
+				q.setLong(ID, lastId);
 				q.setMaxResults(5);
 				return q.list();
 			}
@@ -677,4 +678,5 @@ public class AttendanceDaoImpl extends HibernateDaoSupport implements Attendance
 			return null;
 		}
 	}
+
 }

--- a/impl/src/java/org/sakaiproject/attendance/logic/SakaiProxyImpl.java
+++ b/impl/src/java/org/sakaiproject/attendance/logic/SakaiProxyImpl.java
@@ -360,7 +360,6 @@ public class SakaiProxyImpl implements SakaiProxy {
 						userList.add(student);
 					} catch (UserNotDefinedException e) {
 						log.error("Unable to get user " + member.getUserId() + " " + e);
-						e.printStackTrace();
 					}
 				}
 			}


### PR DESCRIPTION
Seen in production and dev: quartz job will loop forever and ever