### PR TITLE
SAKAI-4582-6 fixing table sorting on main overview and Student overview

### DIFF
--- a/tool/src/java/org/sakaiproject/attendance/tool/Attendance.properties
+++ b/tool/src/java/org/sakaiproject/attendance/tool/Attendance.properties
@@ -60,6 +60,7 @@ attendance.header.grade = Grade
 #Overview Page
 attendance.overview.header = Take Attendance
 attendance.overview.header.event.name = Attendance Item
+attendance.overview.header.event.actions = Actions
 attendance.overview.header.event.date = Date
 attendance.overview.header.event.edit = Edit
 attendance.overview.header.print = Print

--- a/tool/src/java/org/sakaiproject/attendance/tool/pages/BasePage.java
+++ b/tool/src/java/org/sakaiproject/attendance/tool/pages/BasePage.java
@@ -194,8 +194,8 @@ public class BasePage extends WebPage implements IHeaderContributor {
 		//response.renderJavascriptReference("js/my_tool_javascript.js");
 		// tablesorter
 		final String version = ServerConfigurationService.getString("portal.cdn.version", "");
-		response.render(JavaScriptHeaderItem.forUrl(String.format("/library/js/jquery/tablesorter/2.27.7/js/jquery.tablesorter.min.js?version=%s", version)));
-		response.render(JavaScriptHeaderItem.forUrl(String.format("/library/js/jquery/tablesorter/2.27.7/js/jquery.tablesorter.widgets.min.js?version=%s", version)));
+		response.render(JavaScriptHeaderItem.forUrl(String.format("javascript/jquery.tablesorter.min.js?version=%s", version)));
+		response.render(JavaScriptHeaderItem.forUrl(String.format("javascript/jquery.tablesorter.widgets.min.js?version=%s", version)));
 	}
 	
 	/** 

--- a/tool/src/java/org/sakaiproject/attendance/tool/pages/Overview.html
+++ b/tool/src/java/org/sakaiproject/attendance/tool/pages/Overview.html
@@ -36,9 +36,10 @@
 	<table id="overviewTable" class="table table-striped table-bordered overviewTable">
 		<thead>
 			<tr>
-				<th class="col-sm-4" colspan=2 ><span wicket:id="header-event-name" /></th>
-				<th class="col-sm-2"><span wicket:id="header-event-date" /></th>
-				<th class="col-sm-1" wicket:id="status-headers"><span wicket:id="header-status-name" /></th>
+				<th class="col-sm-4 tablesorter-headerUnsorted" ><span wicket:id="header-event-name" /></th>
+				<th class="col-sm-1 {sorter: false}" ><span wicket:id="header-event-actions" /></th>
+				<th class="col-sm-2 tablesorter-headerUnsorted"><span wicket:id="header-event-date" /></th>
+				<th class="col-sm-1 tablesorter-headerUnsorted" wicket:id="status-headers"><span wicket:id="header-status-name" /></th>
 			</tr>
 		</thead>
 		<tbody>
@@ -83,12 +84,7 @@
 		$(document).ready(function(){
 			$("p.overviewInstructions").width($("#overviewTable").outerWidth());
 			$("#overviewTable").tablesorter({
-				sortList: [[1,0],[0,0]],
-				headers: {
-					1: {
-						sorter: "attendanceDate"
-					}
-				}
+				sortList: [[0,0], [2,0]]	//default to sorting by name [column 0] first, then Date [column 2]
 			});
 			$(".takeAttendanceNowForm input").on("click", function(){
 				$("#loadingGif").show();

--- a/tool/src/java/org/sakaiproject/attendance/tool/pages/Overview.java
+++ b/tool/src/java/org/sakaiproject/attendance/tool/pages/Overview.java
@@ -107,6 +107,7 @@ public class Overview extends BasePage {
 
 		//headers for the table
 		Label headerEventName 		= new Label("header-event-name", 			new ResourceModel("attendance.overview.header.event.name"));
+		Label headerEventActions	= new Label("header-event-actions", 		new ResourceModel("attendance.overview.header.event.actions"));
 		Label headerEventDate 		= new Label("header-event-date", 			new ResourceModel("attendance.overview.header.event.date"));
 
 		DataView<AttendanceStatus> statusHeaders = new DataView<AttendanceStatus>("status-headers", attendanceStatusProvider) {
@@ -123,6 +124,7 @@ public class Overview extends BasePage {
 		add(headerOverview);
 		add(headerInfo);
 		add(headerEventName);
+		add(headerEventActions);
 		add(headerEventDate);
 		add(headerEventEdit);
 		add(headerPrintLinks);

--- a/tool/src/java/org/sakaiproject/attendance/tool/pages/StudentOverview.html
+++ b/tool/src/java/org/sakaiproject/attendance/tool/pages/StudentOverview.html
@@ -35,8 +35,8 @@
         <thead>
         <tr>
             <th><span wicket:id="header-student-photo" class="{sorter: false}"/></th>
-            <th class="studentOverviewNameHeader col-sm-5"><span wicket:id="header-student-name" /></th>
-            <th class="col-sm-1" wicket:id="status-headers"><span wicket:id="header-status-name" /></th>
+            <th class="studentOverviewNameHeader col-sm-5 tablesorter-headerUnsorted"><span wicket:id="header-student-name" /></th>
+            <th class="col-sm-1 tablesorter-headerUnsorted" wicket:id="status-headers"><span wicket:id="header-status-name" /></th>
             <th class="col sm-1 overviewGradeCol {sorter: false}">
                 <span wicket:id="header-grade" />
                 <a wicket:id="settings-link">

--- a/tool/src/webapp/css/attendance.css
+++ b/tool/src/webapp/css/attendance.css
@@ -145,16 +145,16 @@ table.itemListTable, table.eventViewTable, table.takeAttendanceTable {
     margin-left: 35px;
 }
 
-thead tr .tablesorter-header:not(.sorter-false):not(.tablesorter-headerAsc):not(.tablesorter-headerDesc), table.itemListTable thead tr .header, table.takeAttendanceTable thead tr .header, th.tablesorter-headerUnsorted  {
+thead tr .tablesorter-header:not(.sorter-false):not(.tablesorter-headerAsc):not(.tablesorter-headerDesc), table.itemListTable thead tr .header, table.takeAttendanceTable thead tr .header, th.tablesorter-headerUnsorted, tr.div-table-row > th.header:not(.headerSortDown):not(.headerSortUp)  {
     background: url(../images/bg.gif) no-repeat bottom .5em right;
     cursor: pointer;
     padding-right: 24px;
 }
 
-thead tr .tablesorter-headerAsc, table.itemListTable thead tr .headerSortUp, table.takeAttendanceTable thead tr .headerSortUp {
+thead tr .tablesorter-headerAsc, table.itemListTable thead tr .headerSortUp, table.takeAttendanceTable thead tr .headerSortUp, th.headerSortUp {
     background: url(../images/asc.gif) no-repeat bottom .5em right;
 }
-thead tr .tablesorter-headerDesc, table.itemListTable thead tr .headerSortDown, table.takeAttendanceTable thead tr .headerSortDown {
+thead tr .tablesorter-headerDesc, table.itemListTable thead tr .headerSortDown, table.takeAttendanceTable thead tr .headerSortDown, th.headerSortDown {
     background: url(../images/desc.gif) no-repeat bottom .5em right;
 }
 
@@ -315,11 +315,10 @@ td.studentNameCol {
 
 .table > tbody > tr > td.itemNameCol {
     font-size: 1.2em;
-    border-right: 1px solid transparent;
 }
 
 td.actionsButtonCol {
-    text-align: right;
+    text-align: center;
 }
 
 th.takeAttendanceNameHeader {


### PR DESCRIPTION
This is a redo of an identical set of changes I made back in October; the Travis build failed for some reason before. It fixes the accidental loss of table sorting on the mail Attendance overview page, and on the Student overview, which Hotelschool The Hague noticed originally.