### PR TITLE
Fixes #85 - RuntimeException running in development because of removed components

### DIFF
--- a/tool/src/java/org/sakaiproject/attendance/tool/pages/Overview.java
+++ b/tool/src/java/org/sakaiproject/attendance/tool/pages/Overview.java
@@ -118,16 +118,11 @@ public class Overview extends BasePage {
 		};
 		add(statusHeaders);
 
-		Label headerEventEdit		= new Label("header-event-edit", 			new ResourceModel("attendance.overview.header.event.edit"));
-		Label headerPrintLinks		= new Label("header-print-links",			new ResourceModel("attendance.overview.header.print"));
-
 		add(headerOverview);
 		add(headerInfo);
 		add(headerEventName);
 		add(headerEventActions);
 		add(headerEventDate);
-		add(headerEventEdit);
-		add(headerPrintLinks);
 
 	}
 


### PR DESCRIPTION
I'm not sure if you're still watching this @davidpbauer 

It looks like you originally worked on some changes for "print links?" in 2016

And it was removed by @jkozar2 in 2019 and caused an error when running Wicket in development. Maybe this is all fine, and just needed to clean up the accompanying code. Or perhaps the components should be added back in. I'm really not 100% sure.

```
commit 59f84bf7db17073af36116da310521c9e74de059
Author: jkozar2 <49496640+jkozar2@users.noreply.github.com>
Date:   Mon Jul 29 11:07:52 2019 -0400

    Improved styling of Attendance tool to match other Sakai tools (#56)

    * SAKAI-4637 complete implementation of proposed Attendance changes

    1. We decided to move the Add Attendance Item functionality to one of the tab buttons across the top to match other tools better.
    2. Tables within the tool are now styled with less complication, using standard Bootstrap tables instead.
    3. Radio buttons for taking attendance are now hidden [except on mobile] and activated with color-coded icons that are easier to click.
    4. All tables are now fitted to the width of the screen to make better use of space.
    5. Actions [such as edit/delete] for items are now grouped within one dropdown for each item.

commit 95579b4779b04f1e8b60eb5737c24e740a1831b9
Author: David P. Bauer <dbauer1@udayton.edu>
Date:   Tue Jan 5 18:08:35 2016 -0500

    SAKAI-2354 More styling work on overview page

commit c4e6abdc7626deac44d20f14f936639496e30481
Author: David P. Bauer <dbauer1@udayton.edu>
Date:   Tue Jan 5 18:08:35 2016 -0500

    SAKAI-2354 More styling work on overview page
```