### PR TITLE
#104 Save "sakai.attendance" in Gradebook items instead of "Attendance" in db to avoid i18n issues

### DIFF
--- a/impl/src/java/org/sakaiproject/attendance/impl/AttendanceGradebookProviderImpl.java
+++ b/impl/src/java/org/sakaiproject/attendance/impl/AttendanceGradebookProviderImpl.java
@@ -63,12 +63,7 @@ public class AttendanceGradebookProviderImpl implements AttendanceGradebookProvi
 
         String siteID = aS.getSiteID();
 
-        Tool tool = toolManager.getCurrentTool();
-        String appName = AttendanceConstants.TOOL_NAME;
-        if(tool != null ) {
-            appName = tool.getTitle();
-
-        }
+        String appName = AttendanceConstants.SAKAI_TOOL_NAME;
 
         String aSUID = getAttendanceUID(aS);
         try {


### PR DESCRIPTION
This change apply the need of execute a conversion script, I will add it in a comment when is merged in sakai-reference

More info about the issue: https://sakaiproject.atlassian.net/browse/SAK-47291