### PR TITLE
Attendance add dropdown to select gradebook category, fixes #110 

### DIFF
--- a/api/src/java/org/sakaiproject/attendance/api/AttendanceGradebookProvider.java
+++ b/api/src/java/org/sakaiproject/attendance/api/AttendanceGradebookProvider.java
@@ -19,6 +19,9 @@ package org.sakaiproject.attendance.api;
 import org.sakaiproject.attendance.model.AttendanceGrade;
 import org.sakaiproject.attendance.model.AttendanceSite;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * A Provider which sends grades to the Gradebook
  *
@@ -31,7 +34,7 @@ public interface AttendanceGradebookProvider {
      * Create a new External Assessment in the Gradebook
      * @param aS, the AttendanceSite
      */
-    boolean create(AttendanceSite aS);
+    boolean create(AttendanceSite aS, String categoryId);
 
     /**
      * Remove an External Assessment from the Gradebook
@@ -43,7 +46,7 @@ public interface AttendanceGradebookProvider {
      * Updates the external Assessment in the Gradebook
      * @param aS
      */
-    boolean update(AttendanceSite aS);
+    boolean update(AttendanceSite aS, String categoryId);
 
     /**
      * Sends an AttendanceGrade to the Gradebook
@@ -51,6 +54,12 @@ public interface AttendanceGradebookProvider {
      * @return success of operation
      */
     boolean sendToGradebook(AttendanceGrade ag);
+
+    boolean doesGradebookHaveCategories(String gbUID);
+
+    Map<String,String> getGradebookCategories(String gbUID);
+
+    Long getCategoryForItem(String gbUID,Long aSID);
 
     /**assignment defined with the provided title
      * @param gbUID

--- a/tool/src/java/org/sakaiproject/attendance/tool/Attendance.properties
+++ b/tool/src/java/org/sakaiproject/attendance/tool/Attendance.properties
@@ -190,7 +190,7 @@ attendance.settings.grading.max.points.possible = Total Points Possible
 attendance.settings.grading.is.grade.shown = Allow students to see their grade within this tool
 attendance.settings.grading.send.to.gradebook = Send grades to the Gradebook
 attendance.settings.grading.gradebook.item.name = Gradebook Item Name
-
+attendance.settings.grading.gradebook.category = Gradebook Category
 attendance.settings.grading.mode = Grading Mode
 attendance.settings.grading.manually = Manually grade students' attendance.
 attendance.settings.grading.auto = Define rules to automatically grade attendance.

--- a/tool/src/java/org/sakaiproject/attendance/tool/panels/AttendanceGradeFormPanel.html
+++ b/tool/src/java/org/sakaiproject/attendance/tool/panels/AttendanceGradeFormPanel.html
@@ -34,6 +34,10 @@
                             <li>
                                 <input type="text" id="gradebookItemName" wicket:id="gradebookItemName" /> <label class="gradeSettingsLabel" for="gradebookItemName" wicket:id="gradebook-item-name" />
                             </li>
+                            <li>
+                                <select id="gradebookCategory" wicket:id="gradebookCategory" />
+                                <label for="gradebookCategory" class="gradeSettingsLabel" wicket:id="gradebookCategoryLabel" />
+                            </li>
                         </ul>
                     </div>
                 </li>


### PR DESCRIPTION
This PR adds a Gradebook Category dropdown to Attendance's Grading settings. It's a feature we added recently at University Of Dayton, and we're sharing it with the community now. It depends on a couple of changes in Gradebook, which we've opened a Sakaiproject Jira to track: https://sakaiproject.atlassian.net/browse/SAK-47743
This PR's Attendance ticket is https://github.com/sakaicontrib/attendance/issues/110.