### PR TITLE
#114 - Clicking import button without file selection causes server error

### DIFF
--- a/tool/src/java/org/sakaiproject/attendance/tool/pages/ExportPage.html
+++ b/tool/src/java/org/sakaiproject/attendance/tool/pages/ExportPage.html
@@ -38,7 +38,7 @@
                 </fieldset>
 
                 <div class="act">
-                    <button type="submit" wicket:id="submitLink" ><wicket:message key="attendance.export.importButton" /></button>
+                    <button type="submit" id="import-button" wicket:id="submitLink" disabled><wicket:message key="attendance.export.importButton" /></button>
                 </div>
             </form>
         </div>

--- a/tool/src/java/org/sakaiproject/attendance/tool/pages/ExportPage.java
+++ b/tool/src/java/org/sakaiproject/attendance/tool/pages/ExportPage.java
@@ -18,11 +18,14 @@ package org.sakaiproject.attendance.tool.pages;
 
 import org.apache.commons.codec.binary.StringUtils;
 import org.apache.wicket.model.StringResourceModel;
+import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.attendance.logic.SakaiProxy;
 import org.sakaiproject.attendance.model.*;
 import org.sakaiproject.user.api.User;
 
 import org.apache.wicket.RestartResponseException;
+import org.apache.wicket.markup.head.IHeaderResponse;
+import org.apache.wicket.markup.head.JavaScriptHeaderItem;
 import org.apache.wicket.markup.html.form.Button;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.SubmitLink;
@@ -496,5 +499,12 @@ public class ExportPage extends BasePage{
             }
             return commentsChanged;
         }
+    }
+
+    @Override
+    public void renderHead(IHeaderResponse response) {
+	    super.renderHead(response);
+	    final String version = ServerConfigurationService.getString("portal.cdn.version", "");
+	    response.render(JavaScriptHeaderItem.forUrl(String.format("javascript/exportPage.js?version=%s", version)));
     }
 }

--- a/tool/src/webapp/javascript/exportPage.js
+++ b/tool/src/webapp/javascript/exportPage.js
@@ -1,0 +1,7 @@
+$(document).ready(function(){
+    $('input[type="file"]').change(function(e){
+        if (this.files.length > 0) {
+	    $("#import-button").prop('disabled', false);
+        }
+    });
+})


### PR DESCRIPTION
Disabling the import button by default and enabling it via jQuery upon the selection of a file can improve the UX of the import function.