### PR TITLE
#116 - Add tab needs validation checks and error messages

### DIFF
--- a/tool/src/java/org/sakaiproject/attendance/tool/pages/EventInputPage.html
+++ b/tool/src/java/org/sakaiproject/attendance/tool/pages/EventInputPage.html
@@ -22,6 +22,7 @@
         <div class="page-header">
             <h1 wicket:id="addItemTitle" class="overHeaderSpan" />
         </div>
+        <div wicket:id="addEditItemFeedback"></div>
         <div class="addItemLine">
             <label wicket:for="name">
                 <wicket:message key="attendance.add.label.name" />

--- a/tool/src/java/org/sakaiproject/attendance/tool/pages/EventInputPage.java
+++ b/tool/src/java/org/sakaiproject/attendance/tool/pages/EventInputPage.java
@@ -42,6 +42,7 @@ public class EventInputPage extends BasePage{
 
     private Form<AttendanceEvent> createEventInputForm() {
         Form<AttendanceEvent> eventForm = new Form<>("event", this.eventModel);
+        eventForm.add(new AttendanceFeedbackPanel("addEditItemFeedback"));
         eventForm.add(new Label("addItemTitle", getString("event.add")));
         AjaxSubmitLink submit = createSubmitLink("submit", eventForm, false);
         submit.add(new Label("submitLabel", new ResourceModel("attendance.add.create")));


### PR DESCRIPTION
Unlike the EventInputPanel, the EventInputPage (or Add tab) does not perform validation checking for the form and feedback errors (or success) to users.

For instance, clicking the Create button on a blank form does not report that an event item name is needed.

This can be fixed by adding an AttendanceFeedbackPanel to the form.